### PR TITLE
Use `Config` from `homeassistant.core_config`

### DIFF
--- a/custom_components/linznetz/__init__.py
+++ b/custom_components/linznetz/__init__.py
@@ -4,7 +4,8 @@ Custom integration to integrate linznetz with Home Assistant.
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 
 from .const import (
     DOMAIN,


### PR DESCRIPTION
The API has changed and needs to be adapted until 12/2025 to close #24.

https://developers.home-assistant.io/blog/2024/10/31/core-config-moved/